### PR TITLE
#17 project and npm package rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# gh-label-maker
+# github-manager-cli
 
 A CLI to add labels for repositories
 
 ```
-npm install -g github-label-maker
+npm install -g github-manager-cli
 ```
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gh-label-maker",
+  "name": "github-manager-cli",
   "version": "1.0.0",
   "description": "GitHub label maker",
   "main": "index.js",


### PR DESCRIPTION
To rename a project and npm package, you have to do the following steps:
- To change project name execute:

`$ git remote set-url origin git@github.com:99xt/github-manager-cli`

or if you are using HTTPS instead of SSH:

`$ git remote set-url origin https://github.com/99xt/github-manager-cli.git`
  
- Regarding rename npm package:  

You can't really do it. You have to create a new one. 
But first you have to label the old one with 'deprecated' notification:

`$ npm deprecate github-label-maker@1.0.0 "WARNING: This module has been renamed to github-manager-cli. Please install it instead. See https://github.com/99xt/github-manager-cli for more information." `

After this, accept my pull request with package name change to `github-manager-cli` and execute:
`$ npm publish`